### PR TITLE
Browser responsive

### DIFF
--- a/browserApp/build/index.html
+++ b/browserApp/build/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, maximum-scale=1, user-scalable=no" />
     <title>Aika</title>
   </head>
   <body>

--- a/browserApp/src/components/CreateSlice.js
+++ b/browserApp/src/components/CreateSlice.js
@@ -110,7 +110,9 @@ const CreateSlice = () => {
       <Header size = 'medium'>New Slice</Header>
       <Form onSubmit = {submitSlice}>
         <Header size = 'tiny'>Title</Header>
-        <FormGroup>
+        <FormGroup
+          className = 'slice-create-title-group'
+          inline>
           <FormInput
             error = {titleError}
             name = 'title'
@@ -121,7 +123,6 @@ const CreateSlice = () => {
             basic = {!thisSlice.isMilestone}
             color = 'vk'
             onClick = {() => dispatch(updateSlice({isMilestone: !thisSlice.isMilestone}))}
-            size = 'small'
             type = 'button'>
               Milestone
           </Button>
@@ -129,7 +130,6 @@ const CreateSlice = () => {
             basic = {!thisSlice.isPublic}
             color = 'vk'
             onClick = {() => dispatch(updateSlice({isPublic: !thisSlice.isPublic}))}
-            size = 'small'
             type = 'button'>
               Public
           </Button>
@@ -160,13 +160,15 @@ const CreateSlice = () => {
           </div>
         </FormGroup>
         }
-        <FormTextArea
-          error = {textError}
-          label = 'Text'
-          name = 'text'
-          onChange = {handleTextChange}
-          placeholder = 'Text'
-          value = {thisSlice.text}/>
+        <div className = 'slice-create-text-area'>
+          <FormTextArea
+            error = {textError}
+            label = 'Text'
+            name = 'text'
+            onChange = {handleTextChange}
+            placeholder = 'Text'
+            value = {thisSlice.text}/>
+        </div>
         <div className = 'slice-button-container'>
           <Button
             fluid

--- a/browserApp/src/components/LogIn.js
+++ b/browserApp/src/components/LogIn.js
@@ -43,6 +43,8 @@ const LogIn = () => {
       <div className = 'generic-flex-column'>
         <div className = 'ui input'>
           <input
+            autoCapitalize = 'off'
+            autoCorrect = 'off'
             type = 'text'
             name = 'username'
             value = {username}

--- a/browserApp/src/components/Register.js
+++ b/browserApp/src/components/Register.js
@@ -21,6 +21,8 @@ const TextField = ({varName, dispName, type = 'text', ...props}) => {
     <FormField>
       <label>{dispName}</label>
       <Input
+        autoCapitalize = 'off'
+        autoCorrect = 'off'
         type = {type}
         name = {varName}
         value = {thisRegistration[varName]}

--- a/browserApp/src/components/Slices.js
+++ b/browserApp/src/components/Slices.js
@@ -234,7 +234,7 @@ const Slices = () => {
       const onScroll = () => {
         const {clientHeight, scrollHeight, scrollTop} = scrollRef.current;
 
-        const scrolledToBottom = scrollTop + clientHeight >= scrollHeight;
+        const scrolledToBottom = scrollTop + clientHeight >= scrollHeight - 10;
         if (scrolledToBottom && !isLoading) {
           dispatch(incrementScroller());
         }

--- a/browserApp/src/index.css
+++ b/browserApp/src/index.css
@@ -117,6 +117,7 @@
   flex-wrap: wrap;
 
   column-gap: 5px;
+  row-gap: 5px;
 }
 
 .permission-bubble-yes, .permission-bubble-no {
@@ -152,6 +153,8 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+
+  row-gap: 5px;
 }
 
 .slice-button-container {
@@ -167,6 +170,15 @@
 
 .slice-create-container-open {
   margin-bottom: 10px;
+}
+
+.slice-create-text-area {
+  margin-top: 15px;
+  margin-bottom: 5px;
+}
+
+.slice-create-title-group {
+  row-gap: 5px;
 }
 
 .slice-image {


### PR DESCRIPTION
Now the browser app is responsive on mobile browsers. Main tweak was a single line that was missing in the html.

A couple outstanding things to keep an eye on:
- Had to add a small buffer zone to the autoscroll, as it didn't seem like the mobile scrolling was quite reaching the bottom. If it's just a constant offset, then it should be sorted. But if the offset scales with the number of slices (or, more precisely, the total scroll height), then at some point this will stop working, and we'll have to add a multiplicative offset (e.g., .95*height).
- One of the streams had much larger text size than the others. I can't replicate it when creating new streams, and I think it's just a quirk of running very large font scaling on my phone. When I adjust the phone settings to default scaling, all the streams have the same text size.