### PR TITLE
Slice Menu

### DIFF
--- a/browserApp/src/components/Slices/index.js
+++ b/browserApp/src/components/Slices/index.js
@@ -51,7 +51,7 @@ const Slices = () => {
       };
     }
 
-  }, [data, scrollRef]);
+  }, [data, myPermissions, scrollRef]);
 
   // error
   if (isError) {

--- a/browserApp/src/index.css
+++ b/browserApp/src/index.css
@@ -169,6 +169,7 @@
 
 .menu-slice-container {
   margin-top: 5px;
+  margin-bottom: 5px;
 
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
- Re-added bottom margin to slice menu, which was missing on Chrome but added automatically on Firefox?
- Another attempt to fix the re-load bug. I'm think now it might have something to do with the event listener for the scrolling not being added.